### PR TITLE
Overloaded SimpleTelegramClient#send

### DIFF
--- a/src/main/java/it/tdlight/client/SimpleTelegramClient.java
+++ b/src/main/java/it/tdlight/client/SimpleTelegramClient.java
@@ -231,7 +231,7 @@ public final class SimpleTelegramClient implements Authenticable {
 	 * Send a function and get the result
 	 */
 	public <R extends TdApi.Object> void send(TdApi.Function<R> function, GenericResultHandler<R> resultHandler) {
-		client.send(function, result -> resultHandler.onResult(Result.of(result)), this::handleResultHandlingException);
+		send(function, result -> resultHandler.onResult(Result.of(result)), this::handleResultHandlingException);
 	}
 
 	/**

--- a/src/main/java/it/tdlight/client/SimpleTelegramClient.java
+++ b/src/main/java/it/tdlight/client/SimpleTelegramClient.java
@@ -235,6 +235,13 @@ public final class SimpleTelegramClient implements Authenticable {
 	}
 
 	/**
+	 * Send a function and get the result
+	 */
+	public <R extends TdApi.Object> void send(TdApi.Function<R> function, GenericResultHandler<R> resultHandler, ExceptionHandler exceptionHandler) {
+		client.send(function, result -> resultHandler.onResult(Result.of(result)), exceptionHandler);
+	}
+
+	/**
 	 * Execute a synchronous function.
 	 * <strong>Please note that only some functions can be executed using this method.</strong>
 	 * If you want to execute a function please use {@link #send(Function, GenericResultHandler)}!


### PR DESCRIPTION
`ExceptionHandler` must be customizable when executing `SimpleTelegramClient#send`