### PR TITLE
Removed Init.start() from Example#main

### DIFF
--- a/example/src/main/java/it/tdlight/example/Example.java
+++ b/example/src/main/java/it/tdlight/example/Example.java
@@ -5,7 +5,6 @@ import it.tdlight.client.AuthenticationData;
 import it.tdlight.client.CommandHandler;
 import it.tdlight.client.SimpleTelegramClient;
 import it.tdlight.client.TDLibSettings;
-import it.tdlight.common.utils.CantLoadLibrary;
 import it.tdlight.jni.TdApi;
 import java.nio.file.Paths;
 
@@ -23,7 +22,7 @@ public final class Example {
 
 	private static SimpleTelegramClient client;
 
-	public static void main(String[] args) throws CantLoadLibrary, InterruptedException {
+	public static void main(String[] args) throws InterruptedException {
 		// Obtain the API token
 		var apiToken = APIToken.example();
 

--- a/example/src/main/java/it/tdlight/example/Example.java
+++ b/example/src/main/java/it/tdlight/example/Example.java
@@ -1,12 +1,10 @@
 package it.tdlight.example;
 
-import it.tdlight.client.*;
+import it.tdlight.client.APIToken;
 import it.tdlight.client.AuthenticationData;
 import it.tdlight.client.CommandHandler;
 import it.tdlight.client.SimpleTelegramClient;
 import it.tdlight.client.TDLibSettings;
-import it.tdlight.common.Init;
-import it.tdlight.common.Log;
 import it.tdlight.common.utils.CantLoadLibrary;
 import it.tdlight.jni.TdApi;
 import java.nio.file.Paths;
@@ -26,9 +24,6 @@ public final class Example {
 	private static SimpleTelegramClient client;
 
 	public static void main(String[] args) throws CantLoadLibrary, InterruptedException {
-		// Initialize TDLight native libraries
-		Init.start();
-
 		// Obtain the API token
 		var apiToken = APIToken.example();
 


### PR DESCRIPTION
No need to call `Init.start()` in `Example#main` since it is already called in static initialization block of `SimpleTelegramClient`:
https://github.com/tdlight-team/tdlight-java/blob/17d55599d283d82e1f10e85b29d95cf354db8f21/src/main/java/it/tdlight/client/SimpleTelegramClient.java#L43-L49