### PR TITLE
Made telegram client daemon

### DIFF
--- a/tdlight-java/src/main/java/it/tdlight/ResponseReceiver.java
+++ b/tdlight-java/src/main/java/it/tdlight/ResponseReceiver.java
@@ -53,7 +53,7 @@ abstract class ResponseReceiver extends Thread implements AutoCloseable {
 	public ResponseReceiver(EventsHandler eventsHandler) {
 		super("TDLib thread");
 		this.eventsHandler = eventsHandler;
-		this.setDaemon(false);
+		this.setDaemon(true);
 	}
 
 	/**


### PR DESCRIPTION
This change will help to use the telegram client from the library as a Spring bean.

If this change is not made, the main thread is blocked and the Spring context cannot be initialized.